### PR TITLE
Support automatically nested configs in env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
 node_js:
+  - "10"
+  - "8"
+  - "6"
   - "4.1"
-  - "4.0"
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
 script:
   - npm run coverage
 after_script:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,40 @@ Add methods may contain options, these include:
 Some additional conifguration parameters and loader options are available to
 further customize the experience.
 
+### Mapping a flat namespace to a structured one (for environment variables)
+
+If you are importing configuration from environment variables you can either
+perform key re-mapping as listed in the next section or you can use double
+underscores to specify hierarchy (i.e. `FOO__BAR`) by using the `underscoreNesting` option.
+
+This means you could remap something like:
+
+``` json
+{
+  "serverConfig": {
+    "port": 9999,
+    "host": "localhost"
+  }
+}
+```
+
+Like so:
+
+``` bash
+SERVER_CONFIG__PORT=9999
+SERVER_CONFIG__HOST=localhost
+```
+
+By doing the following:
+
+``` javascript
+loader.add('./some/file.yaml');
+loader.addAndNormalizeObject(process.env, {underscoreNesting: true})
+loader.load(function(error, config) {
+  console.log(config); // { foo: { bar: { baz: 123 } } }
+});
+```
+
 
 ### Key Re-mapping with Nested Values
 

--- a/test/underscoreNestingTest.js
+++ b/test/underscoreNestingTest.js
@@ -1,0 +1,28 @@
+var should = require('should');
+
+var Loader = require('..');
+
+describe('yaml-config-loader', function() {
+  describe('keys containing dots', function() {
+    it('should map keys containing double underscores into nested objects', function(done) {
+      var loader = new Loader();
+      loader.add({
+        FOO__BAR: 'baz',
+        FOO__BEEP_BOOP: 'blap',
+        beep: 'boop',
+      }, {underscoreNesting: true});
+      loader.add({'abc': 123});
+      loader.load(function(error, config) {
+        should.not.exist(error);
+        config.foo.should.be.an.instanceOf(Object);
+        config.foo.bar.should.be.an.instanceOf(Object);
+        config.foo.beepBoop.should.equal('blap');
+        config.foo.bar.should.equal('baz');
+        config.beep.should.equal('boop');
+        config.abc.should.equal(123);
+        done();
+      });
+    });
+  });
+});
+ 


### PR DESCRIPTION
Configuration files are often structured but this module aims to make it
easy to override config files from environment variables (which do not
support structure or event dot notation in key names. This addittion
provides a magic parameter that, if specified, allows you to dynamically
generate a key mapping for any key that has two `_` characters appearing
in a row.

If you are importing configuration from environment variables you can either
perform key re-mapping as listed in the next section or you can use double
underscores to specify hierarchy (i.e. `FOO__BAR`) by using the `underscoreNesti
g` option.

This means you could remap something like:

``` json
{
  "serverConfig": {
    "port": 9999,
    "host": "localhost"
  }
}
```

Like so:

``` bash
SERVER_CONFIG__PORT=9999
SERVER_CONFIG__HOST=localhost
```